### PR TITLE
Add editor-driven robot command pipeline

### DIFF
--- a/Animation/Assets/Scripts/Editor/RobotCommandDrawer.cs
+++ b/Animation/Assets/Scripts/Editor/RobotCommandDrawer.cs
@@ -1,0 +1,19 @@
+using System.Linq;
+using UnityEditor;
+using UnityEngine;
+
+[CustomPropertyDrawer(typeof(RobotCommand), true)]
+public class RobotCommandDrawer : PropertyDrawer
+{
+    public override float GetPropertyHeight(SerializedProperty property, GUIContent label)
+    {
+        return EditorGUI.GetPropertyHeight(property, label, true);
+    }
+
+    public override void OnGUI(Rect position, SerializedProperty property, GUIContent label)
+    {
+        var type = property.managedReferenceFullTypename.Split(' ').Last();
+        label = new GUIContent(type.Substring(type.LastIndexOf('.') + 1));
+        EditorGUI.PropertyField(position, property, label, true);
+    }
+}

--- a/Animation/Assets/Scripts/Editor/RobotCommandSequenceEditor.cs
+++ b/Animation/Assets/Scripts/Editor/RobotCommandSequenceEditor.cs
@@ -1,0 +1,52 @@
+using UnityEditor;
+using UnityEditorInternal;
+using UnityEngine;
+
+[CustomEditor(typeof(RobotCommandSequence))]
+public class RobotCommandSequenceEditor : Editor
+{
+    ReorderableList _list;
+
+    void OnEnable()
+    {
+        _list = new ReorderableList(serializedObject, serializedObject.FindProperty("commands"), true, true, true, true);
+        _list.drawHeaderCallback = rect => GUI.Label(rect, "Commands");
+        _list.elementHeightCallback = index =>
+        {
+            var element = _list.serializedProperty.GetArrayElementAtIndex(index);
+            return EditorGUI.GetPropertyHeight(element);
+        };
+        _list.drawElementCallback = (rect, index, active, focused) =>
+        {
+            var element = _list.serializedProperty.GetArrayElementAtIndex(index);
+            EditorGUI.PropertyField(rect, element, GUIContent.none, true);
+        };
+        _list.onAddDropdownCallback = (rect, list) =>
+        {
+            var menu = new GenericMenu();
+            menu.AddItem(new GUIContent("Move"), false, () => AddCommand<MoveCommand>());
+            menu.AddItem(new GUIContent("Rotate"), false, () => AddCommand<RotateCommand>());
+            menu.AddItem(new GUIContent("Change Color"), false, () => AddCommand<ColorCommand>());
+            menu.AddItem(new GUIContent("Wait"), false, () => AddCommand<WaitCommand>());
+            menu.ShowAsContext();
+        };
+    }
+
+    void AddCommand<T>() where T : RobotCommand, new()
+    {
+        serializedObject.Update();
+        var prop = serializedObject.FindProperty("commands");
+        int index = prop.arraySize;
+        prop.InsertArrayElementAtIndex(index);
+        var element = prop.GetArrayElementAtIndex(index);
+        element.managedReferenceValue = new T();
+        serializedObject.ApplyModifiedProperties();
+    }
+
+    public override void OnInspectorGUI()
+    {
+        serializedObject.Update();
+        _list.DoLayoutList();
+        serializedObject.ApplyModifiedProperties();
+    }
+}

--- a/Animation/Assets/Scripts/RobotCommand.cs
+++ b/Animation/Assets/Scripts/RobotCommand.cs
@@ -1,0 +1,88 @@
+using UnityEngine;
+using System.Collections;
+
+[System.Serializable]
+public abstract class RobotCommand
+{
+    public abstract IEnumerator Execute(GameObject robot, Renderer renderer);
+}
+
+[System.Serializable]
+public class MoveCommand : RobotCommand
+{
+    public Vector3 position;
+    public float duration = 1f;
+
+    public override IEnumerator Execute(GameObject robot, Renderer renderer)
+    {
+        Vector3 start = robot.transform.position;
+        Vector3 target = position;
+        float time = 0f;
+        while (time < duration)
+        {
+            time += Time.deltaTime;
+            float t = duration > 0f ? time / duration : 1f;
+            robot.transform.position = Vector3.Lerp(start, target, t);
+            yield return null;
+        }
+        robot.transform.position = target;
+    }
+}
+
+[System.Serializable]
+public class RotateCommand : RobotCommand
+{
+    public Vector3 rotation;
+    public float duration = 1f;
+
+    public override IEnumerator Execute(GameObject robot, Renderer renderer)
+    {
+        Vector3 start = robot.transform.eulerAngles;
+        Vector3 target = rotation;
+        float time = 0f;
+        while (time < duration)
+        {
+            time += Time.deltaTime;
+            float t = duration > 0f ? time / duration : 1f;
+            robot.transform.eulerAngles = Vector3.Lerp(start, target, t);
+            yield return null;
+        }
+        robot.transform.eulerAngles = target;
+    }
+}
+
+[System.Serializable]
+public class ColorCommand : RobotCommand
+{
+    public Color color = Color.white;
+    public float duration = 1f;
+
+    public override IEnumerator Execute(GameObject robot, Renderer renderer)
+    {
+        if (renderer == null)
+            yield break;
+
+        Color start = renderer.material.color;
+        Color target = color;
+        float time = 0f;
+        while (time < duration)
+        {
+            time += Time.deltaTime;
+            float t = duration > 0f ? time / duration : 1f;
+            renderer.material.color = Color.Lerp(start, target, t);
+            yield return null;
+        }
+        renderer.material.color = target;
+    }
+}
+
+[System.Serializable]
+public class WaitCommand : RobotCommand
+{
+    public float time = 1f;
+
+    public override IEnumerator Execute(GameObject robot, Renderer renderer)
+    {
+        yield return new WaitForSeconds(time);
+    }
+}

--- a/Animation/Assets/Scripts/RobotCommandSequence.cs
+++ b/Animation/Assets/Scripts/RobotCommandSequence.cs
@@ -1,0 +1,9 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+[CreateAssetMenu(menuName = "Robot/Command Sequence", fileName = "RobotSequence")]
+public class RobotCommandSequence : ScriptableObject
+{
+    [SerializeReference]
+    public List<RobotCommand> commands = new List<RobotCommand>();
+}

--- a/Animation/Assets/Scripts/RobotExecutor.cs
+++ b/Animation/Assets/Scripts/RobotExecutor.cs
@@ -1,0 +1,40 @@
+using UnityEngine;
+using System.Collections;
+
+public class RobotExecutor : MonoBehaviour
+{
+    public RobotCommandSequence sequence;
+
+    private Renderer _renderer;
+    private Coroutine _routine;
+
+    void Start()
+    {
+        _renderer = GetComponent<Renderer>();
+        if (sequence != null)
+            _routine = StartCoroutine(Run());
+    }
+
+    public void Play()
+    {
+        if (sequence != null && _routine == null)
+            _routine = StartCoroutine(Run());
+    }
+
+    public void Stop()
+    {
+        if (_routine != null)
+            StopCoroutine(_routine);
+        _routine = null;
+    }
+
+    IEnumerator Run()
+    {
+        foreach (var command in sequence.commands)
+        {
+            if (command != null)
+                yield return StartCoroutine(command.Execute(gameObject, _renderer));
+        }
+        _routine = null;
+    }
+}

--- a/Animation/Assets/Scripts/RobotSample.cs
+++ b/Animation/Assets/Scripts/RobotSample.cs
@@ -1,0 +1,15 @@
+using UnityEngine;
+
+public class RobotSample : MonoBehaviour
+{
+    public RobotCommandSequence sequence;
+
+    void Start()
+    {
+        var executor = GetComponent<RobotExecutor>();
+        if (executor == null)
+            executor = gameObject.AddComponent<RobotExecutor>();
+        executor.sequence = sequence;
+        executor.Play();
+    }
+}


### PR DESCRIPTION
## Summary
- redesign robot commands into polymorphic objects
- create `RobotCommandSequence` ScriptableObject to store commands
- update `RobotExecutor` to play a command sequence
- add `WaitCommand` for timed pauses
- implement custom inspector to build sequences in Unity Editor

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68862844fc5c83248be81080a91cc0a1