### PR TITLE
Add save/load support for command sequences

### DIFF
--- a/Animation/Assets/Scripts/Editor/RobotCommandSequenceEditor.cs
+++ b/Animation/Assets/Scripts/Editor/RobotCommandSequenceEditor.cs
@@ -1,6 +1,7 @@
 using UnityEditor;
 using UnityEditorInternal;
 using UnityEngine;
+using System.IO;
 
 [CustomEditor(typeof(RobotCommandSequence))]
 public class RobotCommandSequenceEditor : Editor
@@ -47,6 +48,25 @@ public class RobotCommandSequenceEditor : Editor
     {
         serializedObject.Update();
         _list.DoLayoutList();
+        EditorGUILayout.Space();
+        if (GUILayout.Button("Save Commands"))
+        {
+            string path = EditorUtility.SaveFilePanel("Save Robot Commands", "", "RobotCommands.json", "json");
+            if (!string.IsNullOrEmpty(path))
+            {
+                RobotCommandSequenceSerializer.Save((RobotCommandSequence)target, path);
+            }
+        }
+
+        if (GUILayout.Button("Load Commands"))
+        {
+            string path = EditorUtility.OpenFilePanel("Load Robot Commands", "", "json");
+            if (!string.IsNullOrEmpty(path))
+            {
+                RobotCommandSequenceSerializer.Load((RobotCommandSequence)target, path);
+                EditorUtility.SetDirty(target);
+            }
+        }
         serializedObject.ApplyModifiedProperties();
     }
 }

--- a/Animation/Assets/Scripts/Utils/RobotCommandSequenceSerializer.cs
+++ b/Animation/Assets/Scripts/Utils/RobotCommandSequenceSerializer.cs
@@ -1,0 +1,21 @@
+using System.IO;
+using UnityEngine;
+
+public static class RobotCommandSequenceSerializer
+{
+    public static void Save(RobotCommandSequence sequence, string path)
+    {
+        if (sequence == null || string.IsNullOrEmpty(path))
+            return;
+        var json = JsonUtility.ToJson(sequence, true);
+        File.WriteAllText(path, json);
+    }
+
+    public static void Load(RobotCommandSequence sequence, string path)
+    {
+        if (sequence == null || string.IsNullOrEmpty(path) || !File.Exists(path))
+            return;
+        var json = File.ReadAllText(path);
+        JsonUtility.FromJsonOverwrite(json, sequence);
+    }
+}


### PR DESCRIPTION
## Summary
- enable saving and loading of `RobotCommandSequence` data
- add inspector buttons for Save/Load

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68862f3f6ee883248f7fa0bf3c14f147