### PR TITLE
Improve timeline visualization

### DIFF
--- a/Animation/Assets/Scripts/Editor/RobotTimelineWindow.cs
+++ b/Animation/Assets/Scripts/Editor/RobotTimelineWindow.cs
@@ -30,11 +30,16 @@ public class RobotTimelineWindow : EditorWindow
 
         float maxTime = 0f;
         foreach (var entry in _timeline.commands)
-            if (entry != null && entry.startTime > maxTime)
-                maxTime = entry.startTime;
+        {
+            if (entry == null || entry.command == null)
+                continue;
+            float end = entry.startTime + entry.command.GetDuration();
+            if (end > maxTime)
+                maxTime = end;
+        }
 
         Rect rect = GUILayoutUtility.GetRect(position.width - 20, 100);
-        float width = Mathf.Max(rect.width, maxTime * _pixelsPerSecond + 100);
+        float width = Mathf.Max(rect.width, (maxTime + 5f) * _pixelsPerSecond);
         Rect contentRect = new Rect(0, 0, width, rect.height);
         _scroll = GUI.BeginScrollView(rect, _scroll, contentRect);
 
@@ -86,8 +91,23 @@ public class RobotTimelineWindow : EditorWindow
             if (entry == null || entry.command == null)
                 continue;
             float x = entry.startTime * _pixelsPerSecond;
-            Rect r = new Rect(x + 50, 20 + i * 22, 120, 20);
+            float w = Mathf.Max(40, entry.command.GetDuration() * _pixelsPerSecond);
+            Rect r = new Rect(x + 50, 20 + i * 22, w, 20);
+
+            Color prev = GUI.color;
+            GUI.color = GetColorForCommand(entry.command);
             GUI.Box(r, entry.command.GetType().Name);
+            GUI.color = prev;
+        }
+    }
+
+    Color GetColorForCommand(RobotCommand command)
+    {
+        unchecked
+        {
+            int hash = command.GetType().Name.GetHashCode();
+            float hue = (hash & 0xFFFFFF) / (float)0xFFFFFF;
+            return Color.HSVToRGB(hue, 0.6f, 0.8f);
         }
     }
 

--- a/Animation/Assets/Scripts/RobotCommand.cs
+++ b/Animation/Assets/Scripts/RobotCommand.cs
@@ -5,6 +5,16 @@ using System.Collections;
 public abstract class RobotCommand
 {
     public abstract IEnumerator Execute(GameObject robot, Renderer renderer);
+
+    /// <summary>
+    /// Optional duration of the command. Used by the timeline editor to draw the
+    /// command length. Commands that don't have a notion of duration should
+    /// return 0.
+    /// </summary>
+    public virtual float GetDuration()
+    {
+        return 0f;
+    }
 }
 
 [System.Serializable]
@@ -12,6 +22,8 @@ public class MoveCommand : RobotCommand
 {
     public Vector3 position;
     public float duration = 1f;
+
+    public override float GetDuration() => duration;
 
     public override IEnumerator Execute(GameObject robot, Renderer renderer)
     {
@@ -35,6 +47,8 @@ public class RotateCommand : RobotCommand
     public Vector3 rotation;
     public float duration = 1f;
 
+    public override float GetDuration() => duration;
+
     public override IEnumerator Execute(GameObject robot, Renderer renderer)
     {
         Vector3 start = robot.transform.eulerAngles;
@@ -56,6 +70,8 @@ public class ColorCommand : RobotCommand
 {
     public Color color = Color.white;
     public float duration = 1f;
+
+    public override float GetDuration() => duration;
 
     public override IEnumerator Execute(GameObject robot, Renderer renderer)
     {
@@ -80,6 +96,8 @@ public class ColorCommand : RobotCommand
 public class WaitCommand : RobotCommand
 {
     public float time = 1f;
+
+    public override float GetDuration() => time;
 
     public override IEnumerator Execute(GameObject robot, Renderer renderer)
     {


### PR DESCRIPTION
## Summary
- support command durations in RobotCommand via `GetDuration`
- render commands in timeline according to their duration
- extend timeline width and colorize each command uniquely

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6886695ff5f88324af0b0fd248d1af01