### PR TITLE
Add loop control and interactive timeline

### DIFF
--- a/Animation/Assets/Scripts/Editor/RobotCommandSequenceEditor.cs
+++ b/Animation/Assets/Scripts/Editor/RobotCommandSequenceEditor.cs
@@ -47,6 +47,7 @@ public class RobotCommandSequenceEditor : Editor
     public override void OnInspectorGUI()
     {
         serializedObject.Update();
+        EditorGUILayout.PropertyField(serializedObject.FindProperty("loop"));
         _list.DoLayoutList();
         EditorGUILayout.Space();
         if (GUILayout.Button("Save Commands"))

--- a/Animation/Assets/Scripts/Editor/RobotCommandTimelineEditor.cs
+++ b/Animation/Assets/Scripts/Editor/RobotCommandTimelineEditor.cs
@@ -47,6 +47,7 @@ public class RobotCommandTimelineEditor : Editor
     public override void OnInspectorGUI()
     {
         serializedObject.Update();
+        EditorGUILayout.PropertyField(serializedObject.FindProperty("loop"));
         _list.DoLayoutList();
         if (GUILayout.Button("Open Timeline Window"))
         {

--- a/Animation/Assets/Scripts/Editor/RobotTimelineWindow.cs
+++ b/Animation/Assets/Scripts/Editor/RobotTimelineWindow.cs
@@ -7,6 +7,8 @@ public class RobotTimelineWindow : EditorWindow
     RobotCommandTimeline _timeline;
     Vector2 _scroll;
     float _pixelsPerSecond = 100f;
+    int _activeIndex = -1;
+    bool _resizing = false;
 
     [MenuItem("Window/Robot Timeline Editor")]
     public static void OpenWindow()
@@ -26,6 +28,7 @@ public class RobotTimelineWindow : EditorWindow
         _timeline = (RobotCommandTimeline)EditorGUILayout.ObjectField("Timeline", _timeline, typeof(RobotCommandTimeline), false);
         if (_timeline == null)
             return;
+        _timeline.loop = EditorGUILayout.Toggle("Loop", _timeline.loop);
 
         _pixelsPerSecond = EditorGUILayout.Slider("Pixels Per Second", _pixelsPerSecond, 10f, 500f);
 
@@ -86,20 +89,82 @@ public class RobotTimelineWindow : EditorWindow
 
     void DrawCommands()
     {
+        Event e = Event.current;
         for (int i = 0; i < _timeline.commands.Count; i++)
         {
             var entry = _timeline.commands[i];
             if (entry == null || entry.command == null)
                 continue;
+
             float x = entry.startTime * _pixelsPerSecond + LEFT_MARGIN;
             float w = Mathf.Max(40, entry.command.GetDuration() * _pixelsPerSecond);
             Rect r = new Rect(x, 20 + i * 22, w, 20);
+            Rect resize = new Rect(r.xMax - 4, r.y, 4, r.height);
+
+            EditorGUIUtility.AddCursorRect(resize, MouseCursor.ResizeHorizontal);
+            EditorGUIUtility.AddCursorRect(r, MouseCursor.MoveArrow);
+
+            switch (e.type)
+            {
+                case EventType.MouseDown:
+                    if (resize.Contains(e.mousePosition))
+                    {
+                        _activeIndex = i;
+                        _resizing = true;
+                        e.Use();
+                    }
+                    else if (r.Contains(e.mousePosition))
+                    {
+                        _activeIndex = i;
+                        _resizing = false;
+                        e.Use();
+                    }
+                    break;
+                case EventType.MouseDrag:
+                    if (_activeIndex == i)
+                    {
+                        Undo.RecordObject(_timeline, "Move Command");
+                        float delta = e.delta.x / _pixelsPerSecond;
+                        if (_resizing)
+                        {
+                            float newDur = Mathf.Max(0, entry.command.GetDuration() + delta);
+                            SetCommandDuration(entry.command, newDur);
+                        }
+                        else
+                        {
+                            entry.startTime = Mathf.Max(0, entry.startTime + delta);
+                        }
+                        e.Use();
+                        EditorUtility.SetDirty(_timeline);
+                    }
+                    break;
+                case EventType.MouseUp:
+                    if (_activeIndex == i)
+                    {
+                        _activeIndex = -1;
+                        _resizing = false;
+                        e.Use();
+                    }
+                    break;
+            }
 
             Color prev = GUI.color;
             GUI.color = GetColorForCommand(entry.command);
             GUI.Box(r, entry.command.GetType().Name);
             GUI.color = prev;
         }
+    }
+
+    void SetCommandDuration(RobotCommand command, float value)
+    {
+        if (command is MoveCommand m)
+            m.duration = value;
+        else if (command is RotateCommand r)
+            r.duration = value;
+        else if (command is ColorCommand c)
+            c.duration = value;
+        else if (command is WaitCommand w)
+            w.time = value;
     }
 
     Color GetColorForCommand(RobotCommand command)

--- a/Animation/Assets/Scripts/RobotCommandSequence.cs
+++ b/Animation/Assets/Scripts/RobotCommandSequence.cs
@@ -6,4 +6,5 @@ public class RobotCommandSequence : ScriptableObject
 {
     [SerializeReference]
     public List<RobotCommand> commands = new List<RobotCommand>();
+    public bool loop = false;
 }

--- a/Animation/Assets/Scripts/RobotCommandTimeline.cs
+++ b/Animation/Assets/Scripts/RobotCommandTimeline.cs
@@ -5,4 +5,5 @@ using UnityEngine;
 public class RobotCommandTimeline : ScriptableObject
 {
     public List<RobotTimedCommand> commands = new List<RobotTimedCommand>();
+    public bool loop = false;
 }

--- a/Animation/Assets/Scripts/RobotExecutor.cs
+++ b/Animation/Assets/Scripts/RobotExecutor.cs
@@ -38,33 +38,46 @@ public class RobotExecutor : MonoBehaviour
 
     IEnumerator RunSequence()
     {
-        foreach (var command in sequence.commands)
-        {
-            if (command != null)
-                yield return StartCoroutine(command.Execute(gameObject, _renderer));
-        }
-        _routine = null;
-    }
-
-    IEnumerator RunTimeline()
-    {
-        if (timeline.commands.Count == 0)
+        if (sequence == null)
         {
             _routine = null;
             yield break;
         }
 
-        // Start all timed commands as separate coroutines
-        var routines = new System.Collections.Generic.List<Coroutine>();
-        foreach (var entry in timeline.commands)
+        do
         {
-            if (entry.command == null)
-                continue;
-            routines.Add(StartCoroutine(RunTimed(entry)));
+            foreach (var command in sequence.commands)
+            {
+                if (command != null)
+                    yield return StartCoroutine(command.Execute(gameObject, _renderer));
+            }
+        } while (sequence.loop);
+
+        _routine = null;
+    }
+
+    IEnumerator RunTimeline()
+    {
+        if (timeline == null || timeline.commands.Count == 0)
+        {
+            _routine = null;
+            yield break;
         }
-        // Wait for all routines to finish
-        foreach (var r in routines)
-            yield return r;
+
+        do
+        {
+            var routines = new System.Collections.Generic.List<Coroutine>();
+            foreach (var entry in timeline.commands)
+            {
+                if (entry.command == null)
+                    continue;
+                routines.Add(StartCoroutine(RunTimed(entry)));
+            }
+
+            foreach (var r in routines)
+                yield return r;
+        } while (timeline.loop);
+
         _routine = null;
     }
 


### PR DESCRIPTION
## Summary
- add `loop` option to `RobotCommandSequence` and `RobotCommandTimeline`
- let timeline/sequence editors edit the loop flag
- support looping execution in `RobotExecutor`
- enable dragging and resizing commands in `RobotTimelineWindow`
- add loop toggle in timeline window

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688689b675d08324a615cb5a9de41b17