### PR TITLE
Fix timeline window stop behavior

### DIFF
--- a/Animation/Assets/Scripts/Editor/RobotTimelineWindow.cs
+++ b/Animation/Assets/Scripts/Editor/RobotTimelineWindow.cs
@@ -35,6 +35,7 @@ public class RobotTimelineWindow : EditorWindow
     void OnDisable()
     {
         EditorApplication.update -= Update;
+        StopTimeline();
     }
 
     void Update()


### PR DESCRIPTION
## Summary
- reset playback when the timeline window closes

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688744776d9083248eca813d16fce0f6