### PR TITLE
Automate command registration via reflection

### DIFF
--- a/Animation/Assets/Scripts/Editor/RobotCommandRegistry.cs
+++ b/Animation/Assets/Scripts/Editor/RobotCommandRegistry.cs
@@ -1,0 +1,60 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using UnityEditor;
+
+public class RobotCommandInfo
+{
+    public Type Type;
+    public string MenuName;
+    public FieldInfo DurationField;
+}
+
+public static class RobotCommandRegistry
+{
+    static List<RobotCommandInfo> _infos;
+
+    static RobotCommandRegistry()
+    {
+        Load();
+    }
+
+    static void Load()
+    {
+        _infos = new List<RobotCommandInfo>();
+        foreach (var type in TypeCache.GetTypesDerivedFrom<RobotCommand>())
+        {
+            if (type.IsAbstract)
+                continue;
+            var attr = type.GetCustomAttribute<RobotCommandAttribute>();
+            var info = new RobotCommandInfo
+            {
+                Type = type,
+                MenuName = attr?.MenuName ?? ObjectNames.NicifyVariableName(type.Name),
+                DurationField = !string.IsNullOrEmpty(attr?.DurationField)
+                    ? type.GetField(attr.DurationField, BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance)
+                    : null
+            };
+            _infos.Add(info);
+        }
+    }
+
+    public static void PopulateMenu(GenericMenu menu, Action<Type> onSelected)
+    {
+        foreach (var info in _infos)
+        {
+            var t = info.Type;
+            menu.AddItem(new GUIContent(info.MenuName), false, () => onSelected(t));
+        }
+    }
+
+    public static void SetDuration(RobotCommand command, float value)
+    {
+        var info = _infos.FirstOrDefault(i => i.Type == command.GetType());
+        if (info != null && info.DurationField != null)
+        {
+            info.DurationField.SetValue(command, value);
+        }
+    }
+}

--- a/Animation/Assets/Scripts/Editor/RobotCommandSequenceEditor.cs
+++ b/Animation/Assets/Scripts/Editor/RobotCommandSequenceEditor.cs
@@ -1,6 +1,7 @@
 using UnityEditor;
 using UnityEditorInternal;
 using UnityEngine;
+using System;
 using System.IO;
 
 [CustomEditor(typeof(RobotCommandSequence))]
@@ -25,22 +26,19 @@ public class RobotCommandSequenceEditor : Editor
         _list.onAddDropdownCallback = (rect, list) =>
         {
             var menu = new GenericMenu();
-            menu.AddItem(new GUIContent("Move"), false, () => AddCommand<MoveCommand>());
-            menu.AddItem(new GUIContent("Rotate"), false, () => AddCommand<RotateCommand>());
-            menu.AddItem(new GUIContent("Change Color"), false, () => AddCommand<ColorCommand>());
-            menu.AddItem(new GUIContent("Wait"), false, () => AddCommand<WaitCommand>());
+            RobotCommandRegistry.PopulateMenu(menu, type => AddCommand(type));
             menu.ShowAsContext();
         };
     }
 
-    void AddCommand<T>() where T : RobotCommand, new()
+    void AddCommand(Type type)
     {
         serializedObject.Update();
         var prop = serializedObject.FindProperty("commands");
         int index = prop.arraySize;
         prop.InsertArrayElementAtIndex(index);
         var element = prop.GetArrayElementAtIndex(index);
-        element.managedReferenceValue = new T();
+        element.managedReferenceValue = Activator.CreateInstance(type);
         serializedObject.ApplyModifiedProperties();
     }
 

--- a/Animation/Assets/Scripts/Editor/RobotCommandTimelineEditor.cs
+++ b/Animation/Assets/Scripts/Editor/RobotCommandTimelineEditor.cs
@@ -1,6 +1,7 @@
 using UnityEditor;
 using UnityEditorInternal;
 using UnityEngine;
+using System;
 
 [CustomEditor(typeof(RobotCommandTimeline))]
 public class RobotCommandTimelineEditor : Editor
@@ -24,15 +25,12 @@ public class RobotCommandTimelineEditor : Editor
         _list.onAddDropdownCallback = (rect, list) =>
         {
             var menu = new GenericMenu();
-            menu.AddItem(new GUIContent("Move"), false, () => AddCommand<MoveCommand>());
-            menu.AddItem(new GUIContent("Rotate"), false, () => AddCommand<RotateCommand>());
-            menu.AddItem(new GUIContent("Change Color"), false, () => AddCommand<ColorCommand>());
-            menu.AddItem(new GUIContent("Wait"), false, () => AddCommand<WaitCommand>());
+            RobotCommandRegistry.PopulateMenu(menu, type => AddCommand(type));
             menu.ShowAsContext();
         };
     }
 
-    void AddCommand<T>() where T : RobotCommand, new()
+    void AddCommand(Type type)
     {
         serializedObject.Update();
         var prop = serializedObject.FindProperty("commands");
@@ -40,7 +38,7 @@ public class RobotCommandTimelineEditor : Editor
         prop.InsertArrayElementAtIndex(index);
         var element = prop.GetArrayElementAtIndex(index);
         element.FindPropertyRelative("startTime").floatValue = 0f;
-        element.FindPropertyRelative("command").managedReferenceValue = new T();
+        element.FindPropertyRelative("command").managedReferenceValue = Activator.CreateInstance(type);
         serializedObject.ApplyModifiedProperties();
     }
 

--- a/Animation/Assets/Scripts/Editor/RobotTimelineWindow.cs
+++ b/Animation/Assets/Scripts/Editor/RobotTimelineWindow.cs
@@ -1,5 +1,6 @@
 using UnityEditor;
 using UnityEngine;
+using System;
 
 public class RobotTimelineWindow : EditorWindow
 {
@@ -217,14 +218,7 @@ public class RobotTimelineWindow : EditorWindow
 
     void SetCommandDuration(RobotCommand command, float value)
     {
-        if (command is MoveCommand m)
-            m.duration = value;
-        else if (command is RotateCommand r)
-            r.duration = value;
-        else if (command is ColorCommand c)
-            c.duration = value;
-        else if (command is WaitCommand w)
-            w.time = value;
+        RobotCommandRegistry.SetDuration(command, value);
     }
 
     Color GetColorForCommand(RobotCommand command)
@@ -240,14 +234,11 @@ public class RobotTimelineWindow : EditorWindow
     void ShowAddMenu()
     {
         var menu = new GenericMenu();
-        menu.AddItem(new GUIContent("Move"), false, () => AddCommand<MoveCommand>());
-        menu.AddItem(new GUIContent("Rotate"), false, () => AddCommand<RotateCommand>());
-        menu.AddItem(new GUIContent("Change Color"), false, () => AddCommand<ColorCommand>());
-        menu.AddItem(new GUIContent("Wait"), false, () => AddCommand<WaitCommand>());
+        RobotCommandRegistry.PopulateMenu(menu, type => AddCommand(type));
         menu.ShowAsContext();
     }
 
-    void AddCommand<T>() where T : RobotCommand, new()
+    void AddCommand(Type type)
     {
         if (_timeline == null)
             return;
@@ -255,7 +246,7 @@ public class RobotTimelineWindow : EditorWindow
         var entry = new RobotTimedCommand
         {
             startTime = 0f,
-            command = new T()
+            command = (RobotCommand)Activator.CreateInstance(type)
         };
         _timeline.commands.Add(entry);
         EditorUtility.SetDirty(_timeline);

--- a/Animation/Assets/Scripts/RobotCommand.cs
+++ b/Animation/Assets/Scripts/RobotCommand.cs
@@ -17,6 +17,7 @@ public abstract class RobotCommand : IRobotCommand
 }
 
 [System.Serializable]
+[RobotCommand("Move", "duration")]
 public class MoveCommand : RobotCommand
 {
     public Vector3 position;
@@ -47,6 +48,7 @@ public class MoveCommand : RobotCommand
 }
 
 [System.Serializable]
+[RobotCommand("Rotate", "duration")]
 public class RotateCommand : RobotCommand
 {
     public Vector3 rotation;
@@ -77,6 +79,7 @@ public class RotateCommand : RobotCommand
 }
 
 [System.Serializable]
+[RobotCommand("Change Color", "duration")]
 public class ColorCommand : RobotCommand
 {
     public Color color = Color.white;
@@ -110,6 +113,7 @@ public class ColorCommand : RobotCommand
 }
 
 [System.Serializable]
+[RobotCommand("Wait", "time")]
 public class WaitCommand : RobotCommand
 {
     public float time = 1f;

--- a/Animation/Assets/Scripts/RobotCommandAttribute.cs
+++ b/Animation/Assets/Scripts/RobotCommandAttribute.cs
@@ -1,0 +1,14 @@
+using System;
+
+[AttributeUsage(AttributeTargets.Class, Inherited = false)]
+public class RobotCommandAttribute : Attribute
+{
+    public string MenuName { get; }
+    public string DurationField { get; }
+
+    public RobotCommandAttribute(string menuName, string durationField = null)
+    {
+        MenuName = menuName;
+        DurationField = durationField;
+    }
+}


### PR DESCRIPTION
## Summary
- introduce `RobotCommandAttribute` to define menu names and duration fields
- add `RobotCommandRegistry` editor helper to gather all command types
- update editor scripts to populate menus using the registry
- mark commands with the new attribute and simplify duration handling

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68875e67e8588324b0fa88d717a3d18c