### PR TITLE
Fix material leak in editor

### DIFF
--- a/Animation/Assets/Scripts/Commands/ColorCommand.cs
+++ b/Animation/Assets/Scripts/Commands/ColorCommand.cs
@@ -15,17 +15,17 @@ public class ColorCommand : RobotCommand
         if (renderer == null)
             yield break;
 
-        Color start = renderer.material.color;
+        Color start = renderer.sharedMaterial.color;
         Color target = color;
         float time = 0f;
         while (time < duration)
         {
             time += Time.deltaTime;
             float t = duration > 0f ? time / duration : 1f;
-            renderer.material.color = Color.Lerp(start, target, t);
+            renderer.sharedMaterial.color = Color.Lerp(start, target, t);
             yield return null;
         }
-        renderer.material.color = target;
+        renderer.sharedMaterial.color = target;
     }
 
     public override void ApplyState(ref RobotState state, float time)

--- a/Animation/Assets/Scripts/RobotExecutor.cs
+++ b/Animation/Assets/Scripts/RobotExecutor.cs
@@ -139,7 +139,7 @@ public class RobotExecutor : MonoBehaviour
         transform.eulerAngles = state.Rotation;
         transform.localScale = state.Scale;
         if (_renderer)
-            _renderer.material.color = state.Color;
+            _renderer.sharedMaterial.color = state.Color;
     }
 
     private void CacheInitialState()
@@ -149,7 +149,7 @@ public class RobotExecutor : MonoBehaviour
             Position = transform.position,
             Rotation = transform.eulerAngles,
             Scale = transform.localScale,
-            Color = _renderer ? _renderer.material.color : Color.white
+            Color = _renderer ? _renderer.sharedMaterial.color : Color.white
         };
         _cachedState = true;
     }


### PR DESCRIPTION
## Summary
- avoid instantiating materials at edit time by using `sharedMaterial`

## Testing
- `git show --stat`

------
https://chatgpt.com/codex/tasks/task_e_68877a876fb08324a19c4ae63863709c