### PR TITLE
Reset state before each loop

### DIFF
--- a/Animation/Assets/Scripts/RobotExecutor.cs
+++ b/Animation/Assets/Scripts/RobotExecutor.cs
@@ -89,6 +89,8 @@ public class RobotExecutor : MonoBehaviour
 
         do
         {
+            if (_cachedState)
+                ApplyState(_initialState);
             foreach (var command in sequence.commands.Where(command => command != null))
             {
                 yield return StartCoroutine(command.Execute(gameObject, _renderer));
@@ -108,6 +110,8 @@ public class RobotExecutor : MonoBehaviour
 
         do
         {
+            if (_cachedState)
+                ApplyState(_initialState);
             var maxTime = 0f;
             foreach (var entry in timeline.commands.Where(entry => entry.command != null))
             {


### PR DESCRIPTION
## Summary
- keep robot's initial state cached and reset to it at the start of each loop iteration

## Testing
- `dotnet build Animation.sln -v q` *(fails: Assembly-CSharp.csproj not found)*

------
https://chatgpt.com/codex/tasks/task_e_688785a105388324a6dc3bb5f90564a3