### PR TITLE
Fix initial state for timeline playback

### DIFF
--- a/Animation/Assets/Scripts/RobotExecutor.cs
+++ b/Animation/Assets/Scripts/RobotExecutor.cs
@@ -19,6 +19,8 @@ public class RobotExecutor : MonoBehaviour
         _renderer = GetComponent<Renderer>();
         CacheInitialState();
         RobotTime.TimeScale = timeScale;
+        if (_routine != null) return;
+
         if (timeline)
             _routine = StartCoroutine(RunTimeline());
         else if (sequence)
@@ -28,6 +30,9 @@ public class RobotExecutor : MonoBehaviour
     public void Play()
     {
         if (_routine != null) return;
+
+        if (_renderer == null)
+            _renderer = GetComponent<Renderer>();
 
         if (!_cachedState)
             CacheInitialState();
@@ -152,6 +157,8 @@ public class RobotExecutor : MonoBehaviour
 
     private void CacheInitialState()
     {
+        if (_renderer == null)
+            _renderer = GetComponent<Renderer>();
         _initialState = new RobotState
         {
             Position = transform.position,


### PR DESCRIPTION
## Summary
- ensure RobotExecutor doesn't start twice
- cache renderer before capturing the initial state
- recover renderer in `CacheInitialState`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68879a6473808324a0bc4c26004c557f