### PR TITLE
Fix timeline preview to respect context

### DIFF
--- a/Animation/Assets/Scripts/Editor/RobotTimelineWindow.cs
+++ b/Animation/Assets/Scripts/Editor/RobotTimelineWindow.cs
@@ -281,6 +281,7 @@ public class RobotTimelineWindow : EditorWindow
             executor = _target.AddComponent<RobotExecutor>();
         executor.timeline = _timeline;
         executor.timeScale = _timeScale;
+        executor.RefreshInitialState();
         executor.Stop();
         if (EditorApplication.isPlaying)
             executor.Play();
@@ -313,6 +314,7 @@ public class RobotTimelineWindow : EditorWindow
         if (!executor)
             executor = _target.AddComponent<RobotExecutor>();
         executor.timeline = _timeline;
+        executor.RefreshInitialState();
         executor.Stop();
         executor.Preview(time);
     }

--- a/Animation/Assets/Scripts/RobotExecutor.cs
+++ b/Animation/Assets/Scripts/RobotExecutor.cs
@@ -71,18 +71,16 @@ public class RobotExecutor : MonoBehaviour
         {
             if (entry.command == null)
                 continue;
-            var start = entry.startTime;
+
+            var local = time - entry.startTime;
+            if (local <= 0f)
+                continue;
+
             var dur = entry.command.GetDuration();
-            
-            if (time >= start + dur)
-            {
-                entry.command.ApplyState(ref state, dur);
-            }
-            else if (time >= start)
-            {
-                entry.command.ApplyState(ref state, time - start);
-                break;
-            }
+            if (local > dur)
+                local = dur;
+
+            entry.command.ApplyState(ref state, local);
         }
 
         ApplyState(state);
@@ -153,6 +151,11 @@ public class RobotExecutor : MonoBehaviour
         transform.localScale = state.Scale;
         if (_renderer)
             _renderer.sharedMaterial.color = state.Color;
+    }
+
+    public void RefreshInitialState()
+    {
+        CacheInitialState();
     }
 
     private void CacheInitialState()


### PR DESCRIPTION
## Summary
- capture the object's current state before playing the timeline
- accumulate overlapping commands during preview
- update the timeline window to refresh the executor state before playing or previewing

## Testing
- `mcs @csfiles.txt` *(fails: unexpected symbol `{`)*

------
https://chatgpt.com/codex/tasks/task_e_68879cce6efc832489ed8536eaa5d0e1