### PR TITLE
Refactor serialization helpers and executor

### DIFF
--- a/Animation/Assets/Scripts/RobotExecutor.cs
+++ b/Animation/Assets/Scripts/RobotExecutor.cs
@@ -19,25 +19,26 @@ public class RobotExecutor : MonoBehaviour
     {
         _renderer = GetComponent<Renderer>();
         CacheInitialState();
-        RobotTime.TimeScale = timeScale;
-        if (_routine != null) return;
-
-        if (timeline)
-            _routine = StartTrackedCoroutine(RunTimeline());
-        else if (sequence)
-            _routine = StartTrackedCoroutine(RunSequence());
+        StartExecution();
     }
 
     public void Play()
     {
-        if (_routine != null) return;
-
         if (_renderer == null)
             _renderer = GetComponent<Renderer>();
 
         if (!_cachedState)
             CacheInitialState();
+
+        StartExecution();
+    }
+
+    private void StartExecution()
+    {
+        if (_routine != null) return;
+
         RobotTime.TimeScale = timeScale;
+
         if (timeline)
             _routine = StartTrackedCoroutine(RunTimeline());
         else if (sequence)

--- a/Animation/Assets/Scripts/Utils/RobotCommandSequenceSerializer.cs
+++ b/Animation/Assets/Scripts/Utils/RobotCommandSequenceSerializer.cs
@@ -1,21 +1,14 @@
-using System.IO;
 using UnityEngine;
 
 public static class RobotCommandSequenceSerializer
 {
     public static void Save(RobotCommandSequence sequence, string path)
     {
-        if (!sequence || string.IsNullOrEmpty(path))
-            return;
-        var json = JsonUtility.ToJson(sequence, true);
-        File.WriteAllText(path, json);
+        ScriptableObjectSerializer.Save(sequence, path);
     }
 
     public static void Load(RobotCommandSequence sequence, string path)
     {
-        if (!sequence || string.IsNullOrEmpty(path) || !File.Exists(path))
-            return;
-        var json = File.ReadAllText(path);
-        JsonUtility.FromJsonOverwrite(json, sequence);
+        ScriptableObjectSerializer.Load(sequence, path);
     }
 }

--- a/Animation/Assets/Scripts/Utils/RobotCommandTimelineSerializer.cs
+++ b/Animation/Assets/Scripts/Utils/RobotCommandTimelineSerializer.cs
@@ -1,21 +1,14 @@
-using System.IO;
 using UnityEngine;
 
 public static class RobotCommandTimelineSerializer
 {
     public static void Save(RobotCommandTimeline timeline, string path)
     {
-        if (!timeline || string.IsNullOrEmpty(path))
-            return;
-        var json = JsonUtility.ToJson(timeline, true);
-        File.WriteAllText(path, json);
+        ScriptableObjectSerializer.Save(timeline, path);
     }
 
     public static void Load(RobotCommandTimeline timeline, string path)
     {
-        if (!timeline || string.IsNullOrEmpty(path) || !File.Exists(path))
-            return;
-        var json = File.ReadAllText(path);
-        JsonUtility.FromJsonOverwrite(json, timeline);
+        ScriptableObjectSerializer.Load(timeline, path);
     }
 }

--- a/Animation/Assets/Scripts/Utils/ScriptableObjectSerializer.cs
+++ b/Animation/Assets/Scripts/Utils/ScriptableObjectSerializer.cs
@@ -1,0 +1,21 @@
+using System.IO;
+using UnityEngine;
+
+public static class ScriptableObjectSerializer
+{
+    public static void Save<T>(T obj, string path) where T : ScriptableObject
+    {
+        if (!obj || string.IsNullOrEmpty(path))
+            return;
+        var json = JsonUtility.ToJson(obj, true);
+        File.WriteAllText(path, json);
+    }
+
+    public static void Load<T>(T obj, string path) where T : ScriptableObject
+    {
+        if (!obj || string.IsNullOrEmpty(path) || !File.Exists(path))
+            return;
+        var json = File.ReadAllText(path);
+        JsonUtility.FromJsonOverwrite(json, obj);
+    }
+}


### PR DESCRIPTION
## Summary
- extract generic `ScriptableObjectSerializer` to remove duplication
- update command serializers to use the new helper
- refactor `RobotExecutor` to reduce duplicate code

## Testing
- `dotnet build Animation.sln` *(fails: project files missing)*

------
https://chatgpt.com/codex/tasks/task_e_6887a739e5848324802ae90e0a294c13