### PR TITLE
Improve executor and window composition

### DIFF
--- a/Animation/Assets/Scripts/RobotExecutor.cs
+++ b/Animation/Assets/Scripts/RobotExecutor.cs
@@ -15,21 +15,23 @@ public class RobotExecutor : MonoBehaviour
     private RobotState _initialState;
     private bool _cachedState = false;
 
+    private void EnsureInitialized()
+    {
+        if (_renderer == null)
+            _renderer = GetComponent<Renderer>();
+        if (!_cachedState)
+            CacheInitialState();
+    }
+
     private void Start()
     {
-        _renderer = GetComponent<Renderer>();
-        CacheInitialState();
+        EnsureInitialized();
         StartExecution();
     }
 
     public void Play()
     {
-        if (_renderer == null)
-            _renderer = GetComponent<Renderer>();
-
-        if (!_cachedState)
-            CacheInitialState();
-
+        EnsureInitialized();
         StartExecution();
     }
 
@@ -58,7 +60,7 @@ public class RobotExecutor : MonoBehaviour
     {
         if (!timeline)
             return;
-        _renderer = GetComponent<Renderer>();
+        EnsureInitialized();
 
         var sorted = new List<RobotTimedCommand>(timeline.commands);
         sorted.Sort((a, b) => a.startTime.CompareTo(b.startTime));

--- a/Animation/Assets/Scripts/RobotSample.cs
+++ b/Animation/Assets/Scripts/RobotSample.cs
@@ -6,9 +6,7 @@ public class RobotSample : MonoBehaviour
 
     private void Start()
     {
-        var executor = GetComponent<RobotExecutor>();
-        if (!executor)
-            executor = gameObject.AddComponent<RobotExecutor>();
+        var executor = gameObject.GetOrAddComponent<RobotExecutor>();
         executor.sequence = sequence;
         executor.Play();
     }

--- a/Animation/Assets/Scripts/Utils/GameObjectExtensions.cs
+++ b/Animation/Assets/Scripts/Utils/GameObjectExtensions.cs
@@ -1,0 +1,12 @@
+using UnityEngine;
+
+public static class GameObjectExtensions
+{
+    public static T GetOrAddComponent<T>(this GameObject go) where T : Component
+    {
+        var component = go.GetComponent<T>();
+        if (!component)
+            component = go.AddComponent<T>();
+        return component;
+    }
+}


### PR DESCRIPTION
## Summary
- add `GetOrAddComponent` extension for reusing component creation logic
- streamline RobotSample usage of RobotExecutor
- simplify RobotTimelineWindow's executor retrieval
- centralize RobotExecutor initialization logic

## Testing
- `git diff --check`


------
https://chatgpt.com/codex/tasks/task_e_6887b34bfa5483249c385e66a35ee8cb